### PR TITLE
fix: simplify header by removing subtitle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,6 @@
             <div class="header-content">
                 <div class="header-text">
                     <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
                 </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Remove small headline 'Ask questions about courses, instructors, and content' from header, keeping only the main 'Course Materials Assistant' title.

Fixes #4